### PR TITLE
adding support for debian 6

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -8,21 +8,47 @@
 #  include java7
 class java7 {
   case $::operatingsystem {
-    debian, ubuntu: {
+    debian: {
       include apt
+      
+      apt::source { 'webupd8team': 
+	location          => "http://ppa.launchpad.net/webupd8team/java/ubuntu",
+        release           => "precise",
+        repos             => "main",
+        #required_packages => "debian-keyring debian-archive-keyring",
+        key               => "EEA14886",
+        key_server        => "keyserver.ubuntu.com",
+        include_src       => true
+      }
+      package { 'oracle-java7-installer':
+        responsefile => '/tmp/java.preseed',
+        require      => [
+                          Apt::Source['webupd8team'],
+                          File['/tmp/java.preseed']
+                        ],
+      }
+   }
+   ubuntu: {
+     include apt
 
       apt::ppa { 'ppa:webupd8team/java': }
-      file { '/tmp/java.preseed':
-        source => 'puppet:///modules/java7/java.preseed',
-        mode   => '0600',
-        backup => false,
-      }
       package { 'oracle-java7-installer':
         responsefile => '/tmp/java.preseed',
         require      => [
                           Apt::Ppa['ppa:webupd8team/java'],
                           File['/tmp/java.preseed']
                         ],
+      }
+   }
+   default: { notice "Unsupported operatingsystem ${::operatingsystem}" }
+ }
+
+  case $::operatingsystem {
+    debian, ubuntu: {
+      file { '/tmp/java.preseed':
+        source => 'puppet:///modules/java7/java.preseed',
+        mode   => '0600',
+        backup => false,
       }
     }
     default: { notice "Unsupported operatingsystem ${::operatingsystem}" }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -15,7 +15,6 @@ class java7 {
 	location          => "http://ppa.launchpad.net/webupd8team/java/ubuntu",
         release           => "precise",
         repos             => "main",
-        #required_packages => "debian-keyring debian-archive-keyring",
         key               => "EEA14886",
         key_server        => "keyserver.ubuntu.com",
         include_src       => true


### PR DESCRIPTION
This adds support for debian by adding the ubuntu ppa as an apt-source. tested with debian 6.0.6. I didn't do regression-testing on ubuntu though
